### PR TITLE
Return raw values only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,10 +160,10 @@ Fetch Financials With RapidAPI
    25674999808
 
    >>> financials.most_recent_yearly_earnings
-   {'date': 2019, 'revenue': {'raw': 287022000, 'fmt': '287.02M', 'longFmt': '287,022,000'}, 'earnings': {'raw': -105828000, 'fmt': '-105.83M', 'longFmt': '-105,828,000'}}
+   {'date': 2019, 'revenue': 287022000, 'earnings': -105828000}
 
    >>> financials.most_recent_quarterly_earnings
-   {'date': '3Q2020', 'revenue': {'raw': 114162000, 'fmt': '114.16M', 'longFmt': '114,162,000'}, 'earnings': {'raw': -26468000, 'fmt': '-26.47M', 'longFmt': '-26,468,000'}}
+   {'date': '3Q2020', 'revenue': 114162000, 'earnings': -26468000}
 
    >>> historical_data = get_historical_data("MSFT")
    >>> historical_data.first_trade_date

--- a/finance/ext/rapidapi/yahoo/models.py
+++ b/finance/ext/rapidapi/yahoo/models.py
@@ -21,7 +21,11 @@ class Financials:
         recent_earnings = earnings[-1]
         assert recent_earnings["date"] == recent_year
 
-        return recent_earnings
+        return {
+            "date": recent_earnings["date"],
+            "revenue": recent_earnings["revenue"]["raw"],
+            "earnings": recent_earnings["earnings"]["raw"],
+        }
 
     @property
     def most_recent_quarterly_earnings(self):
@@ -36,7 +40,11 @@ class Financials:
         recent_earnings = earnings[-1]
         assert recent_earnings["date"] == recent_quarter
 
-        return recent_earnings
+        return {
+            "date": recent_earnings["date"],
+            "revenue": recent_earnings["revenue"]["raw"],
+            "earnings": recent_earnings["earnings"]["raw"],
+        }
 
 
 class HistoricalData:

--- a/tests/ext/test_rapidapi_yahoo.py
+++ b/tests/ext/test_rapidapi_yahoo.py
@@ -13,6 +13,14 @@ def test_financials():
     financials = Financials(load_test_data("financials-NET.json"))
     assert financials.market_cap == 25324675072
 
+    assert financials.most_recent_yearly_earnings["date"] == 2019
+    assert financials.most_recent_yearly_earnings["revenue"] == 287022000
+    assert financials.most_recent_yearly_earnings["earnings"] == -105828000
+
+    assert financials.most_recent_quarterly_earnings["date"] == "3Q2020"
+    assert financials.most_recent_quarterly_earnings["revenue"] == 114162000
+    assert financials.most_recent_quarterly_earnings["earnings"] == -26468000
+
 
 def test_profile():
     profile = Profile(load_test_data("profile-TSLA.json"))


### PR DESCRIPTION
## Changelog

- In financials, return raw values only (rather than having formatted values as well).